### PR TITLE
feat: set primary color

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -94,7 +94,7 @@ function NavbarList(props) {
           {Object.keys(buttonMap[auth.user.role].buttons).map((key) => (
             <div
               key={key}
-              className="border-2 border-yellow-600 rounded-2xl text-yellow-600 flex flex-row w-full h-12 justify-start content-center p-2 hover:bg-yellow-600 hover:text-white cursor-pointer"
+              className="border-2 border-primary rounded-2xl text-primary flex flex-row w-full h-12 justify-start content-center p-2 hover:bg-primary hover:text-white cursor-pointer"
               onClick={() => {
                 navigate(buttonMap[auth.user.role].buttons[key].path);
                 props.setOpen(false);
@@ -114,7 +114,7 @@ function NavbarList(props) {
           {Object.keys(buttonMap[auth.user.role].navs).map((key) => (
             <div
               key={key}
-              className="border-b-2 border-grey flex flex-row w-full h-12 justify-start content-center p-2 hover:bg-yellow-600 hover:text-white cursor-pointer"
+              className="border-b-2 border-grey flex flex-row w-full h-12 justify-start content-center p-2 hover:bg-primary hover:text-white cursor-pointer"
               onClick={() => {
                 navigate(buttonMap[auth.user.role].navs[key].path);
                 props.setOpen(false);

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -9,4 +9,20 @@ module.exports = {
     extend: {},
   },
   plugins: [require("daisyui"), require("tw-elements/dist/plugin")],
+  daisyui: {
+    themes: [
+      {
+        light: {
+          ...require("daisyui/src/colors/themes")["[data-theme=light]"],
+          primary: "#f97316",
+        },
+      },
+      {
+        dark: {
+          ...require("daisyui/src/colors/themes")["[data-theme=dark]"],
+          primary: "#f97316",
+        },
+      },
+    ],
+  },
 };


### PR DESCRIPTION
just config the primary color
currently we do not have a place for secondary color...
for grey...so first it should not be a secondary color(this should be another color). then even if we would like to make a standard for this, we actually do not have a variable to call it (like we call `primary` for the orange)..so there is no need to set a grey now