### PR TITLE
Password reset logic, admin account create, employer self sign up (UI not done)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "react-hot-toast": "^2.4.0",
         "react-router-dom": "^6.4.3",
         "source-map": "^0.7.4",
-        "tw-elements": "^1.0.0-beta1"
+        "tw-elements": "^1.0.0-beta1",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.24",
@@ -6128,6 +6129,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
@@ -10750,6 +10759,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "vite": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-hot-toast": "^2.4.0",
     "react-router-dom": "^6.4.3",
     "source-map": "^0.7.4",
-    "tw-elements": "^1.0.0-beta1"
+    "tw-elements": "^1.0.0-beta1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.24",

--- a/src/clients/firebase.js
+++ b/src/clients/firebase.js
@@ -6,11 +6,14 @@ import firebaseConfig from "@/firebaseConfig";
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
+const subApp = initializeApp(firebaseConfig, "secondary");
 
 // Initialize Realtime Database and get a reference to the service
 const database = getFirestore(app);
+const subDatabase = getFirestore(subApp);
 const auth = getAuth(app);
+const subAuth = getAuth(subApp);
 
 export default database;
 
-export { auth };
+export { auth, subAuth, subDatabase };

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -16,8 +16,7 @@ const buttonMap = {
     buttons: {
       "Create Account": {
         icon: <AddIcon />,
-        // todo: add path
-        path: "",
+        path: "admin/accounts/create",
       },
       "Post a Job": {
         icon: <AddIcon />,

--- a/src/components/job/jobList/JobList.jsx
+++ b/src/components/job/jobList/JobList.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import AbcIcon from "@mui/icons-material/Abc";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
@@ -7,7 +6,6 @@ import FilterAltIcon from "@mui/icons-material/FilterAlt";
 import LanguageIcon from "@mui/icons-material/Language";
 import LocalHospitalIcon from "@mui/icons-material/LocalHospital";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
-import SearchIcon from "@mui/icons-material/Search";
 import WorkIcon from "@mui/icons-material/Work";
 import { useRequest } from "ahooks";
 import _ from "lodash";
@@ -54,7 +52,7 @@ export default function JobList() {
     },
     {
       manual: true,
-      onError: (error) => {
+      onError: () => {
         toast.error("Failed to get job list");
       },
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,7 +7,6 @@ export const ROLES = {
 export const USER_STATUS = {
   PENDING: "pending",
   APPROVED: "approved",
-  INITIAL: "initial",
 };
 
 export const ENGLISH_LEVEL = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,7 @@ export const ROLES = {
 export const USER_STATUS = {
   PENDING: "pending",
   APPROVED: "approved",
+  INITIAL: "initial",
 };
 
 export const ENGLISH_LEVEL = {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -17,6 +17,7 @@ import { JobSaveContextProvider } from "./models/jobSave";
 const AddJob = lazy(async () => import("@/pages/AddJob"));
 const Admin = {
   Jobs: lazy(async () => import("@/pages/admin/JobsAdmin")),
+  AccountCreate: lazy(async () => import("@/pages/admin/AccountCreate")),
 };
 
 const SignUp = lazy(async () => import("@/pages/SignUp"));
@@ -78,6 +79,15 @@ const router = createBrowserRouter([
               {
                 path: ":tabUrl",
                 element: <Admin.Jobs />,
+              },
+            ],
+          },
+          {
+            path: "accounts",
+            children: [
+              {
+                path: "create",
+                element: <Admin.AccountCreate />,
               },
             ],
           },

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -39,6 +39,10 @@ const router = createBrowserRouter([
     path: "/signIn",
     element: <SignIn />,
   },
+  {
+    path: "/signUp",
+    element: <SignUp />,
+  },
   // all the pages below requires signed in
   {
     path: "/",
@@ -50,10 +54,6 @@ const router = createBrowserRouter([
       {
         index: true,
         element: <Center />,
-      },
-      {
-        path: "signUp",
-        element: <SignUp />,
       },
       {
         path: "addJob",

--- a/src/models/admin.jsx
+++ b/src/models/admin.jsx
@@ -23,31 +23,8 @@ const AdminContext = createContext({
   countUsers: (_queryConstraints) => Number,
 });
 
-const updateUser = async (userId, payload) => {
-  if (payload.id) {
-    delete payload.id;
-  }
-
-  await runTransaction(database, async (transaction) => {
-    const userDocRef = doc(database, "Users", userId);
-    const userDoc = await transaction.get(userDocRef);
-    if (!userDoc.exists()) {
-      throw `User ${userId} does not exist`;
-    }
-    transaction.update(userDocRef, payload);
-  });
-};
-
-const approveUser = async (userId) => {
-  await updateUser(userId, { status: USER_STATUS.APPROVED });
-};
-
 const AdminContextProvider = ({ children }) => {
-  // todo: somewhere deny access, should be in main.jsx
-  //   if (auth.user.role !== ROLES.ADMIN) {
-  //     console.error("?");
-  //   }
-
+  const auth = useAuth();
   const listUsers = async (queryConstraints) => {
     const userCollection = collection(database, "Users");
     const userQuery = queryConstraints
@@ -77,6 +54,29 @@ const AdminContextProvider = ({ children }) => {
       : userCollection;
     const snapshot = await getCountFromServer(userQuery);
     return snapshot.data().count;
+  };
+
+  const updateUser = async (userId, payload) => {
+    if (payload.id) {
+      delete payload.id;
+    }
+
+    await runTransaction(database, async (transaction) => {
+      const userDocRef = doc(database, "Users", userId);
+      const userDoc = await transaction.get(userDocRef);
+      if (!userDoc.exists()) {
+        throw `User ${userId} does not exist`;
+      }
+      transaction.update(userDocRef, payload);
+    });
+  };
+
+  const approveUser = async (userId, user) => {
+    // Approve an employer account, send to his email the password reset email as to notify him the approval
+    if (user.role === ROLES.EMPLOYER) {
+      await updateUser(userId, { status: USER_STATUS.INITIAL });
+      await auth.resetPassWordByEmail(user.email);
+    }
   };
 
   const value = useMemo(

--- a/src/models/admin.jsx
+++ b/src/models/admin.jsx
@@ -74,7 +74,7 @@ const AdminContextProvider = ({ children }) => {
   const approveUser = async (userId, user) => {
     // Approve an employer account, send to his email the password reset email as to notify him the approval
     if (user.role === ROLES.EMPLOYER) {
-      await updateUser(userId, { status: USER_STATUS.INITIAL });
+      await updateUser(userId, { status: USER_STATUS.APPROVED });
       await auth.resetPassWordByEmail(user.email);
     }
   };

--- a/src/models/auth.jsx
+++ b/src/models/auth.jsx
@@ -3,6 +3,7 @@ import {
   createUserWithEmailAndPassword,
   EmailAuthProvider,
   reauthenticateWithCredential,
+  sendPasswordResetEmail,
   signInWithEmailAndPassword,
   signOut as firebaseSignOut,
   updatePassword as firebaseUpdatePassword,
@@ -37,6 +38,7 @@ const AuthContext = createContext({
   updatePassword: async () => {},
   updateProfile: async () => {},
   isSignedIn: () => Boolean,
+  resetpassWordByEmail: async () => {},
 });
 
 const AuthContextProvider = ({ children }) => {
@@ -91,6 +93,10 @@ const AuthContextProvider = ({ children }) => {
     await subAuth.signOut();
   };
 
+  const resetpassWordByEmail = async (email) => {
+    await sendPasswordResetEmail(subAuth, email);
+  };
+
   const signOut = () => {
     return firebaseSignOut(auth);
   };
@@ -128,6 +134,7 @@ const AuthContextProvider = ({ children }) => {
       updatePassword,
       updateProfile,
       isSignedIn,
+      resetpassWordByEmail,
     }),
     [user]
   );

--- a/src/models/auth.jsx
+++ b/src/models/auth.jsx
@@ -84,7 +84,7 @@ const AuthContextProvider = ({ children }) => {
       role,
       phone,
       company,
-      status: role === ROLES.ADMIN ? USER_STATUS.APPROVED : USER_STATUS.PENDING,
+      status: role === ROLES.EMPLOYER ? USER_STATUS.PENDING : USER_STATUS.INITIAL,
     };
     await setDoc(doc(subDatabase, "Users", credential.user.uid), userDoc);
     await subAuth.signOut();

--- a/src/models/auth.jsx
+++ b/src/models/auth.jsx
@@ -90,7 +90,7 @@ const AuthContextProvider = ({ children }) => {
       role,
       phone,
       company,
-      status: role === ROLES.EMPLOYER ? USER_STATUS.PENDING : USER_STATUS.INITIAL,
+      status: role === ROLES.EMPLOYER ? USER_STATUS.PENDING : USER_STATUS.APPROVED,
     };
     await setDoc(doc(subDatabase, "Users", credential.user.uid), userDoc);
     await subAuth.signOut();
@@ -154,10 +154,7 @@ function RequireAuth({ children }) {
       <Spin className="h-10 w-10" />
     </Center>
   );
-  const accessDenied =
-    auth.user &&
-    (auth.user.status === USER_STATUS.INITIAL ||
-      auth.user.status === USER_STATUS.PENDING);
+  const accessDenied = auth.user && auth.user.status === USER_STATUS.PENDING;
 
   const { run, loading } = useRequest(
     async () => {

--- a/src/models/auth.jsx
+++ b/src/models/auth.jsx
@@ -72,7 +72,6 @@ const AuthContextProvider = ({ children }) => {
 
   // Sign Up
   const signUp = async (payload) => {
-    setUser(AUTH_INITIAL_STATE);
     const { email, password, name, phone, role, company } = payload;
     // if we are creating a refugee account, the payload may not have a password.
     // so we generate a uuid() as default value, mark the account as PENDING

--- a/src/models/auth.jsx
+++ b/src/models/auth.jsx
@@ -78,7 +78,7 @@ const AuthContextProvider = ({ children }) => {
   const signUp = async (payload) => {
     const { email, password, name, phone, role, company } = payload;
     // if we are creating a refugee account, the payload may not have a password.
-    // so we generate a uuid() as default value, mark the account as PENDING
+    // so we generate a uuid() as default value, mark the account as INITIAL
     let credential = await createUserWithEmailAndPassword(
       subAuth,
       email,

--- a/src/models/auth.jsx
+++ b/src/models/auth.jsx
@@ -38,7 +38,11 @@ const AuthContext = createContext({
   updatePassword: async () => {},
   updateProfile: async () => {},
   isSignedIn: () => Boolean,
-  resetpassWordByEmail: async () => {},
+  /**
+   *
+   * @param {string} _email
+   */
+  resetPassWordByEmail: async (_email) => {},
 });
 
 const AuthContextProvider = ({ children }) => {
@@ -92,7 +96,7 @@ const AuthContextProvider = ({ children }) => {
     await subAuth.signOut();
   };
 
-  const resetpassWordByEmail = async (email) => {
+  const resetPassWordByEmail = async (email) => {
     await sendPasswordResetEmail(subAuth, email);
   };
 
@@ -133,7 +137,7 @@ const AuthContextProvider = ({ children }) => {
       updatePassword,
       updateProfile,
       isSignedIn,
-      resetpassWordByEmail,
+      resetPassWordByEmail,
     }),
     [user]
   );

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -2,6 +2,7 @@
 import EmailIcon from "@mui/icons-material/Email";
 import LockIcon from "@mui/icons-material/Lock";
 import { useRequest } from "ahooks";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-hot-toast";
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
@@ -15,9 +16,9 @@ export default function SignIn() {
   const navigate = useNavigate();
   const from = location.state?.from?.pathname || "/";
 
-  //   if (auth.isSignedIn) {
-  //     return <Navigate to="/" replace />;
-  //   }
+  if (auth.isSignedIn()) {
+    return <Navigate to="/" replace />;
+  }
 
   // follow this function for a better practice with interactive button
   const { run: signIn, loading: signInLoading } = useRequest(

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,8 +1,6 @@
-/* eslint-disable no-unused-vars */
 import EmailIcon from "@mui/icons-material/Email";
 import LockIcon from "@mui/icons-material/Lock";
 import { useRequest } from "ahooks";
-import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-hot-toast";
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -3,9 +3,13 @@ import { useForm } from "react-hook-form";
 import { toast } from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 
+import { ROLES } from "@/constants";
 import { useAuth } from "@/models";
-
-export default function SignUp() {
+/**
+ * this is for employer self-service sign up.
+ * this page can be accessed without sign in
+ */
+export default function EmployerSignUp() {
   const auth = useAuth();
   const navigate = useNavigate();
   const { register, handleSubmit } = useForm();
@@ -15,21 +19,33 @@ export default function SignUp() {
     {
       manual: true,
       onSuccess: async () => {
-        toast.success("Registration Successful");
-        navigate("/");
+        toast.success(
+          "Registration Successful. Please wait for approval from the admin team"
+        );
+        // todo: should redirect to login page
+        navigate("/signIn");
       },
-      onError: () => {
-        toast.error("Registration Failed");
+      onError: (error) => {
+        toast.error("Registration Failed: " + error.message);
       },
     }
   );
+
+  const onSubmit = async (data) => {
+    await signUp({
+      ...data,
+      role: ROLES.EMPLOYER,
+    });
+  };
 
   return (
     <div className="flex flex-col justify-center items-center">
       <div className="card max-w-md">
         <div className="card-body">
           <p className="mb-5 text-2xl">Register With RefugeeOne Job Search Portal</p>
-          <form onSubmit={handleSubmit(signUp)}>
+          {/* @tianchi @neha todo: may add an explantion for the sign up here */}
+          <p>@tianchi @neha We could add a explanation here</p>
+          <form onSubmit={handleSubmit(onSubmit)}>
             <label className="label" htmlFor="name">
               <span className="label-text">Full Name</span>
             </label>
@@ -68,14 +84,6 @@ export default function SignUp() {
             <input
               {...register("password", { required: true })}
               type="password"
-              className="input w-full max-w-xs input-bordered mb-4"
-            />
-            <label className="label" htmlFor="role">
-              <span className="label-text">Role</span>
-            </label>
-            <input
-              {...register("role", { value: "employer" })}
-              type="text"
               className="input w-full max-w-xs input-bordered mb-4"
             />
             <button

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -77,17 +77,18 @@ export default function EmployerSignUp() {
               type="number"
               className="input w-full input-bordered mb-4"
             />
-            <label className="label" htmlFor="password">
-              <span className="label-text">Password</span>
+            <label className="label" htmlFor="role">
+              <span className="label-text">Role</span>
             </label>
             <input
-              {...register("password", { required: true })}
-              type="password"
-              className="input w-full input-bordered mb-4"
+              {...register("role", { value: "employer" })}
+              type="text"
+              className="input w-full input-bordered mb-8"
+              disabled
             />
             <button
               type="submit"
-              className={`btn btn-primary ${signUpLoading ? "loading" : ""}`}
+              className={`btn btn-primary${signUpLoading ? "loading" : ""}`}
               disabled={signUpLoading}
             >
               {signUpLoading ? "Loading" : "Sign Up"}

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -22,7 +22,6 @@ export default function EmployerSignUp() {
         toast.success(
           "Registration Successful. Please wait for approval from the admin team"
         );
-        // todo: should redirect to login page
         navigate("/signIn");
       },
       onError: (error) => {
@@ -52,7 +51,7 @@ export default function EmployerSignUp() {
             <input
               {...register("name", { required: true })}
               type="text"
-              className="input w-full max-w-xs input-bordered"
+              className="input w-full input-bordered"
             />
             <label className="label" htmlFor="email">
               <span className="label-text">Email</span>
@@ -60,7 +59,7 @@ export default function EmployerSignUp() {
             <input
               {...register("email", { required: true })}
               type="email"
-              className="input w-full max-w-xs input-bordered mb-4"
+              className="input w-full input-bordered mb-4"
             />
             <label className="label" htmlFor="compnay">
               <span className="label-text">Company Name</span>
@@ -68,7 +67,7 @@ export default function EmployerSignUp() {
             <input
               {...register("company")}
               type="text"
-              className="input w-full max-w-xs input-bordered mb-4"
+              className="input w-full input-bordered mb-4"
             />
             <label className="label" htmlFor="phone">
               <span className="label-text">Phone Number</span>
@@ -76,7 +75,7 @@ export default function EmployerSignUp() {
             <input
               {...register("phone", { required: true })}
               type="number"
-              className="input w-full max-w-xs input-bordered mb-4"
+              className="input w-full input-bordered mb-4"
             />
             <label className="label" htmlFor="password">
               <span className="label-text">Password</span>
@@ -84,7 +83,7 @@ export default function EmployerSignUp() {
             <input
               {...register("password", { required: true })}
               type="password"
-              className="input w-full max-w-xs input-bordered mb-4"
+              className="input w-full input-bordered mb-4"
             />
             <button
               type="submit"

--- a/src/pages/admin/AccountCreate.jsx
+++ b/src/pages/admin/AccountCreate.jsx
@@ -1,0 +1,104 @@
+import { useRequest } from "ahooks";
+import { useForm } from "react-hook-form";
+import { toast } from "react-hot-toast";
+
+import { ROLES } from "@/constants";
+// import { ROLES } from "@/constants";
+import { useAuth } from "@/models";
+/**
+ * this is for admin to create an account.
+ * this page could only be visited by admin
+ */
+export default function AccountCreate() {
+  const auth = useAuth();
+  const { register, handleSubmit } = useForm();
+
+  const { run: signUp, loading: signUpLoading } = useRequest(
+    async (data) => auth.signUp(data),
+    {
+      manual: true,
+      onSuccess: async () => {
+        toast.success(
+          "The account has been created. The new user should set the password before sign in."
+        );
+      },
+      onError: (error) => {
+        toast.error("Create account Failed: " + error.message);
+      },
+    }
+  );
+
+  const onSubmit = async (data) => {
+    await signUp({
+      ...data,
+      phone: 999999999,
+      company: "default",
+    });
+  };
+
+  return (
+    <div className="flex flex-col justify-center items-center">
+      <div className="card max-w-md">
+        <div className="card-body">
+          <p className="mb-5 text-2xl">Create an Account</p>
+          {/* @tianchi @neha todo: may add an explantion for the sign up here */}
+          <p>@tianchi @neha We could add a explanation here</p>
+          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+            <div>
+              <label className="label" htmlFor="name">
+                <span className="label-text">Full Name</span>
+              </label>
+              <input
+                {...register("name", { required: true })}
+                type="text"
+                className="input w-full input-bordered"
+              />
+            </div>
+            <div>
+              <label className="label" htmlFor="email">
+                <span className="label-text">Email</span>
+              </label>
+              <input
+                {...register("email", { required: true })}
+                type="email"
+                className="input w-full input-bordered"
+              />
+            </div>
+            <div>
+              <label className="label" htmlFor="role">
+                <span className="label-text">Role</span>
+              </label>
+              <div className="flex flex-row justify-start gap-16">
+                {[ROLES.ADMIN, ROLES.CLIENT].map((item, index) => {
+                  return (
+                    <label
+                      className="label cursor-pointer flex flex-row gap-4"
+                      key={index}
+                    >
+                      <input
+                        type="radio"
+                        name="RADIO_ROLE"
+                        className="radio radio-primary"
+                        {...register("role")}
+                        value={item}
+                        //   checked the first radio
+                      />
+                      <span className="label-text">{item}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+            <button
+              type="submit"
+              className={`btn btn-primary ${signUpLoading ? "loading" : ""}`}
+              disabled={signUpLoading}
+            >
+              {signUpLoading ? "Loading" : "Create Account"}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
1. employ sign up page can be accessed without sign in. no password, location is needed for sign up.
2. `/admin/accounts/create` is where admin can create admin/client account. Only admin can access this page. No password, location, phone number needed.

Notes:
- We should have some place to inform user that, to see the job distance, they have to set the location in the profile @10RE 
- An admin/client user created by admin will be status `approved`. @kendebacker **No need for an initial state, I realized what I said at the meeting is not the best way. When a employer is approved, he will just go to `approved` state**.

3. An email reset function in `auth` model. It does not require any sign in or role. @kendebacker 
4. All user with their password unset, employer with account not approved cannot access the website except sign in and self sign up.
5. When approve an employer account, the system will send to his email address a password reset email to notify the approval @kendebacker  Check [7cc1dc3](https://github.com/RefugeeOne699/refugee-one/pull/53/commits/7cc1dc34c9fe99bebae1b41da0967b322ae1ef73)